### PR TITLE
5995/6287 – Update open and read timeout

### DIFF
--- a/lib/pender_client.rb
+++ b/lib/pender_client.rb
@@ -50,6 +50,8 @@ module PenderClient
 
       http = Net::HTTP.new(uri.hostname, uri.port)
       http.use_ssl = uri.scheme == 'https'
+      http.open_timeout = 5
+      http.read_timeout = 30
       response = http.request(request)
       if response.code.to_i === 401
         raise 'Unauthorized'


### PR DESCRIPTION
# Description
As part of implementing timeout and fallback for `original_claim` URL processing, we are specifying the open and read timeout in the Pender client gem. 

Note: I specified the same timeouts as in 2243.

References: CV2-5995, CV2-6287
Relates to: PR [2243](https://github.com/meedan/check-api/pull/2243)